### PR TITLE
Disable Focus Point params on NUKE macOS to prevent crash (Issue #24)

### DIFF
--- a/README_OFX.md
+++ b/README_OFX.md
@@ -129,7 +129,7 @@ The following issues originate from the OpenDefocus Rust core and affect both ND
 
 | # | Issue | Status | Detail |
 |---|-------|--------|--------|
-| 24 | Focus Point XY overlay crash in NUKE macOS | DEFERRED (host-side) | NUKE macOS crashes when Use Focus Point is enabled. Flame macOS works correctly with the same binary. The plugin uses standard OFX overlay API with OpenGL immediate mode (same pattern as OFX SDK examples). The host is responsible for providing a compatible OpenGL context. Not an OFX plugin-side issue. Workaround: do not enable Use Focus Point in NUKE macOS; use Focus Plane parameter directly |
+| 24 | Focus Point XY overlay crash in NUKE macOS | MITIGATED (host-side) | NUKE macOS crashes when Use Focus Point is enabled. Flame macOS works correctly with the same binary. The plugin uses standard OFX overlay API with OpenGL immediate mode (same pattern as OFX SDK examples). The host is responsible for providing a compatible OpenGL context. **Mitigation**: on macOS + NUKE, the Use Focus Point and Focus Point XY parameters are automatically hidden and disabled (`setIsSecretAndDisabled`). Use Focus Plane parameter directly. Linux/Windows NUKE and all Flame builds are unaffected |
 
 ### Architecture
 

--- a/plugin/OpenDefocusOFX/src/OpenDefocusOFX.cpp
+++ b/plugin/OpenDefocusOFX/src/OpenDefocusOFX.cpp
@@ -1340,6 +1340,9 @@ void OpenDefocusPluginFactory::describeInContext(
     bool isFlame = (hostName.find("Autodesk") != std::string::npos ||
                     hostName.find("Flame")    != std::string::npos ||
                     hostName.find("flame")    != std::string::npos);
+    bool isNuke  = (hostName.find("nuke") != std::string::npos ||
+                    hostName.find("Nuke") != std::string::npos ||
+                    hostName.find("NUKE") != std::string::npos);
 
     // ==========================================================
     // 1. Pages (Tabs) の定義
@@ -1454,12 +1457,17 @@ void OpenDefocusPluginFactory::describeInContext(
     }
 
     // Use Focus Point (toggle)
+    // Disabled on NUKE macOS: NUKE's OpenGL context causes crash with overlay
+    // rendering (Known Issue #24). Flame macOS works correctly.
     {
         OFX::BooleanParamDescriptor* param = desc.defineBooleanParam(kParamUseFocusPoint);
         param->setLabels("Use Focus Point", "Use Focus Point", "Use Focus Point");
         param->setHint("Sample depth at XY position to set focus distance. "
             "Don't animate this - use Focus Plane for animation.");
         param->setDefault(false);
+#ifdef __APPLE__
+        if (isNuke) { param->setIsSecret(true); param->setEnabled(false); }
+#endif
         if (controlsGrp) param->setParent(*controlsGrp);
     }
 
@@ -1471,6 +1479,9 @@ void OpenDefocusPluginFactory::describeInContext(
         param->setDoubleType(OFX::eDoubleTypeXYAbsolute);
         param->setDefaultCoordinateSystem(OFX::eCoordinatesCanonical);
         param->setDefault(25.0, 25.0);
+#ifdef __APPLE__
+        if (isNuke) { param->setIsSecret(true); param->setEnabled(false); }
+#endif
         if (controlsGrp) param->setParent(*controlsGrp);
     }
 


### PR DESCRIPTION
NUKE macOS crashes when Use Focus Point overlay is enabled due to host-side OpenGL context incompatibility. Hide and disable the Use Focus Point and Focus Point XY parameters on macOS + NUKE builds using __APPLE__ guard. Linux/Windows NUKE and all Flame builds are unaffected.